### PR TITLE
Use GIT_REV if set

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,22 @@ $ dokku plugin:install https://github.com/iloveitaly/dokku-rollbar.git
 ```
 
 The plugin pulls the Rollbar access token from your app's `ROLLBAR_TOKEN` and
-your environment from `RAILS_ENV`. The app environment will default to `production`
-if `RAILS_ENV` is not found
+your environment from `ROLLBAR_ENV`, `RAILS_ENV` or `RACK_ENV`. The app environment
+will default to `production` if none of them is not set.
+
+## Dependencies
+
+There is an issue with the way old versions extract the git commit hash
+(see [#4](https://github.com/iloveitaly/dokku-rollbar/issues/4))
+
+For now we use the `GIT_REV` variable set by [dokku-git-rev](https://github.com/dokku-community/dokku-git-rev)
+which is supposed to be part of dokku core in future versions.
+`dokku-rollbar` will work without the plugin installed, but will report an incorrect
+commit hash.
+
+```sh
+$ dokku plugin:install https://github.com/dokku-community/dokku-git-rev.git --name dokku-git-rev
+```
 
 ## Commands
 

--- a/post-deploy
+++ b/post-deploy
@@ -9,8 +9,8 @@ if [[ $ROLLBAR_TOKEN ]]; then
 
   ENVIRONMENT=$(
     dokku config:get "$APP" ROLLBAR_ENV ||
-    dokku config:get "$APP" RACK_ENV ||
     dokku config:get "$APP" RAILS_ENV ||
+    dokku config:get "$APP" RACK_ENV ||
     echo 'production'
   )
   REVISION=$(cd $DOKKU_ROOT/$APP && git log -n 1 --pretty=format:"%H" 2>/dev/null)

--- a/post-deploy
+++ b/post-deploy
@@ -13,7 +13,14 @@ if [[ $ROLLBAR_TOKEN ]]; then
     dokku config:get "$APP" RACK_ENV ||
     echo 'production'
   )
-  REVISION=$(cd $DOKKU_ROOT/$APP && git log -n 1 --pretty=format:"%H" 2>/dev/null)
+
+  REVISION="$GIT_REV"
+  if [[ ! $REVISION ]]; then
+    echo "       WARNING: \$GIT_REV is not set - fall back to parsing git commit hash from git log"
+    echo "       You should install dokku-git-rev plugin to fix this error. See https://github.com/iloveitaly/dokku-rollbar/issues/4"
+    REVISION=$(cd $DOKKU_ROOT/$APP && git log -n 1 --pretty=format:"%H" 2>/dev/null)
+  fi
+
   LOCAL_USERNAME=`whoami`
 
   ROLLBAR_RESULT=$(curl -s https://api.rollbar.com/api/1/deploy/ \


### PR DESCRIPTION
This resolves #4 getting an incorrect commit hash in post-deploy hook.
    
If GIT_REV is set by dokku-git-rev plugin (or in future hopefully by
dokku core), skip parsing the commit hash from git log.
If GIT_REV is not set, fall back to previous buggy implementation and
echo warning message.