### PR TITLE
Use Dokku's new GIT_REV config value

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,11 @@ will default to `production` if none of them is not set.
 
 ## Dependencies
 
-There is an issue with the way old versions extract the git commit hash
-(see [#4](https://github.com/iloveitaly/dokku-rollbar/issues/4))
+**As of Dokku 0.12, `GIT_REV` is set as a config value during a git deployment.**
 
-For now we use the `GIT_REV` variable set by [dokku-git-rev](https://github.com/dokku-community/dokku-git-rev)
-which is supposed to be part of dokku core in future versions.
-`dokku-rollbar` will work without the plugin installed, but will report an incorrect
-commit hash.
+For Dokku < 0.12, we use the `GIT_REV` variable set by [dokku-git-rev](https://github.com/dokku-community/dokku-git-rev).
+
+`dokku-rollbar` will work without the plugin installed, but will report an incorrect commit hash.
 
 ```sh
 $ dokku plugin:install https://github.com/dokku-community/dokku-git-rev.git --name dokku-git-rev

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ will default to `production` if none of them is not set.
 
 For Dokku < 0.12, we use the `GIT_REV` variable set by [dokku-git-rev](https://github.com/dokku-community/dokku-git-rev).
 
-`dokku-rollbar` will work without the plugin installed, but will report an incorrect commit hash.
-
 ```sh
 $ dokku plugin:install https://github.com/dokku-community/dokku-git-rev.git --name dokku-git-rev
 ```
+
+`dokku-rollbar` will work without `GIT_REV` being available, but may report an incorrect commit hash.
 
 ## Commands
 

--- a/post-deploy
+++ b/post-deploy
@@ -3,6 +3,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP="$1"
 ROLLBAR_TOKEN=$(dokku config:get "$APP" ROLLBAR_TOKEN || echo)
+GIT_REV=$(dokku config:get "$APP" GIT_REV || echo "$GIT_REV")
 
 if [[ $ROLLBAR_TOKEN ]]; then
   echo "-----> Notifying Rollbar ..."
@@ -16,8 +17,8 @@ if [[ $ROLLBAR_TOKEN ]]; then
 
   REVISION="$GIT_REV"
   if [[ ! $REVISION ]]; then
-    echo "       WARNING: \$GIT_REV is not set - fall back to parsing git commit hash from git log"
-    echo "       You should install dokku-git-rev plugin to fix this error. See https://github.com/iloveitaly/dokku-rollbar/issues/4"
+    echo "       WARNING: \$GIT_REV is not available - falling back to parsing git commit hash from git log"
+    echo "       On Dokku < 0.12.0, install dokku-git-rev plugin to fix this error. See https://github.com/iloveitaly/dokku-rollbar/issues/4"
     REVISION=$(cd $DOKKU_ROOT/$APP && git log -n 1 --pretty=format:"%H" 2>/dev/null)
   fi
 


### PR DESCRIPTION
With a fallback to the dokku-git-rev plugin's $GIT_REV

Fixes #6